### PR TITLE
Allow using "fallback" and "receive" as identifiers

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -371,7 +371,7 @@ numberLiteral
   : (DecimalNumber | HexNumber) NumberUnit? ;
 
 identifier
-  : ('from' | 'calldata' | 'receive' | 'callback' | Identifier) ;
+  : ('from' | 'calldata' | 'receive' | 'callback' | 'payable' | Identifier) ;
 
 BooleanLiteral
   : 'true' | 'false' ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -371,7 +371,7 @@ numberLiteral
   : (DecimalNumber | HexNumber) NumberUnit? ;
 
 identifier
-  : ('from' | 'calldata' | Identifier) ;
+  : ('from' | 'calldata' | 'receive' | 'callback' | Identifier) ;
 
 BooleanLiteral
   : 'true' | 'false' ;


### PR DESCRIPTION
I don't love this solution, but it seems to work. I think the grammar could be better structured while still avoiding this issue, but I'm not familiar enough with ANTLR yet, so I'd rather make this small adjustment.