### PR TITLE
Add immutable keyword to state variable declaration

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -53,7 +53,7 @@ contractPart
 
 stateVariableDeclaration
   : typeName
-    ( PublicKeyword | InternalKeyword | PrivateKeyword | ConstantKeyword | overrideSpecifier )*
+    ( PublicKeyword | InternalKeyword | PrivateKeyword | ConstantKeyword | ImmutableKeyword | overrideSpecifier )*
     identifier ('=' expression)? ';' ;
 
 usingForDeclaration
@@ -425,6 +425,7 @@ ReservedKeyword
 AnonymousKeyword : 'anonymous' ;
 BreakKeyword : 'break' ;
 ConstantKeyword : 'constant' ;
+ImmutableKeyword : 'immutable' ;
 ContinueKeyword : 'continue' ;
 LeaveKeyword : 'leave' ;
 ExternalKeyword : 'external' ;

--- a/test.sol
+++ b/test.sol
@@ -790,3 +790,11 @@ contract VirtualOverdide is VirtualA, VirtualB {
         super.funA();
     }
 }
+
+contract stateVariables {
+    bytes32 constant adminRole = keccak256("ADMIN_ROLE");
+    uint immutable totalSupply;
+    constructor(uint _totalSupply) public {
+        totalSupply = _totalSupply;
+    }
+}


### PR DESCRIPTION
Adds the `immutable` keyword to state variable declarations as outlined in https://github.com/solidity-parser/antlr/issues/4
