### PR TITLE
Add SPDX-License-Identifier

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -5,7 +5,10 @@
 grammar Solidity;
 
 sourceUnit
-  : (pragmaDirective | importDirective | contractDefinition | enumDefinition | structDefinition)* EOF ;
+  : (spdxLicense | pragmaDirective | importDirective | contractDefinition | enumDefinition | structDefinition)* EOF ;
+
+spdxLicense
+  : '//' 'SPDX-License-Identifier' identifier ;
 
 pragmaDirective
   : 'pragma' pragmaName pragmaValue ';' ;


### PR DESCRIPTION
Solidity 0.6.8 introduces SPDX license identifiers so developers can specify the license the contract uses. [Source](https://github.com/ethereum/solidity/releases/tag/v0.6.8)

This PR is a start to implement this, but I encountered conflicts with:
```
LINE_COMMENT
  : '//' ~[\r\n]* -> channel(HIDDEN)
```
Surely there is a way to differentiate between `// SPDX-License-Identifier: MIT` and `// Random comment`

Any help is very appreciated!
