### PR TITLE
fix(semver): add missing version operator

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -28,7 +28,7 @@ version
   : versionConstraint ('||'? versionConstraint)* ;
 
 versionOperator
-  : '^' | '~' | '>=' | '>' | '<' | '<=' | '=' ;
+  : '^' | '~' | '>=' | '>' | '<' | '<=' | '=' | '||' ;
 
 versionConstraint
   : versionOperator? VersionLiteral


### PR DESCRIPTION
According to the official documentation, the solidity compiler uses `npm` syntax for versions, see: [solidity.readthedocs.io/en/develop/layout-of-source-files.html#pragmas](https://docs.soliditylang.org/en/develop/layout-of-source-files.html#version-pragma)

This fixes the missing pipe operator to denote multiple versions of support, e.g. " 0.5.0 || 0.6.0 "