### PR TITLE
Update assembly assignment and local definition rules

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -353,13 +353,15 @@ assemblyCall
   : ( 'return' | 'address' | 'byte' | identifier ) ( '(' assemblyExpression? ( ',' assemblyExpression )* ')' )? ;
 
 assemblyLocalDefinition
-  : 'let' assemblyIdentifierOrList ( ':=' assemblyExpression )? ;
+  : 'let' assemblyIdentifier ( ':=' assemblyExpression )?
+  | 'let' assemblyIdentifierList ( ':=' assemblyCall )? ;
 
 assemblyAssignment
-  : assemblyIdentifierOrList ':=' assemblyExpression ;
+  : assemblyIdentifier ':=' assemblyExpression
+  | assemblyIdentifierList ':=' assemblyCall;
 
-assemblyIdentifierOrList
-  : identifier | assemblyMember | '(' assemblyIdentifierList ')' ;
+assemblyIdentifier
+  : identifier | assemblyMember;
 
 assemblyIdentifierList
   : identifier ( ',' identifier )* ;

--- a/test.sol
+++ b/test.sol
@@ -480,7 +480,7 @@ contract test {
 			// function dispatcher
 			switch div(calldataload(0), exp(2, 226))
 			case 0xb3de648b {
-				let (r) := f(calldataload(4))
+				let r := f(calldataload(4))
 				let ret := $allocate(0x20)
 				mstore(ret, r)
 				return(ret, 0x20)
@@ -890,4 +890,20 @@ library FixedMath {
 // issue #59
 contract C {
   using L.Lib for uint;
+}
+
+// issue #60
+contract AssemblyAssingment {
+    function foo() public pure {
+        assembly {
+            function bar() -> a, b {
+                a := 1
+                b := 2
+            }
+
+            let i, j
+            let k, l := bar()
+            i, j := bar()
+        }
+    }
 }


### PR DESCRIPTION
The existing rule doesn't allow to assign values to a list of
variables without using parentheses.

The existing rule doesn't also enforce the rule that multi-assignments
can be used only with values returned by a function call.

I've updated both `assemblyLocalDefinition` and `assemblyAssignment`
to allow multi-assignments only before a function call and I've also
removed the ability to wrap a list of identifiers with parentheses
because that doesn't look to be supported anymore.

See [ethereum/solidity/blob/develop/docs/grammar/SolidityParser.g4](https://github.com/ethereum/solidity/blob/47d77931747aba8e364452537d989b795df7ca04/docs/grammar/SolidityParser.g4#L526-L538)

Closes https://github.com/solidity-parser/parser/issues/60