### PR TITLE
Add BooleanLiteral to AssemblyLiteral

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -403,7 +403,7 @@ assemblyIf
   : 'if' assemblyExpression assemblyBlock ;
 
 assemblyLiteral
-  : stringLiteral | DecimalNumber | HexNumber | hexLiteral ;
+  : stringLiteral | DecimalNumber | HexNumber | hexLiteral | BooleanLiteral ;
 
 subAssembly
   : 'assembly' identifier assemblyBlock ;

--- a/test.sol
+++ b/test.sol
@@ -171,6 +171,20 @@ library FixedMath {
 }
 
 /*
+ * Assembly
+ */
+
+contract BooleanLiteralsInAssembly {
+  function f() {
+    uint a;
+    assembly {
+      a := true
+      a := false
+    }
+  }
+}
+
+/*
  * Etc
  */
 


### PR DESCRIPTION
`@solidity-parser/parser` doesn't support inline assembly which uses `true` and `false` literals. I believe this change fixes that after rebuilding everything