### PR TITLE
Removing exception on empty block

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -176,7 +176,7 @@ stateMutability
   : PureKeyword | ConstantKeyword | ViewKeyword | PayableKeyword ;
 
 block
-  : '{' statement* '}' ;
+  : '{' statement* '}' | '{}' ;
 
 statement
   : ifStatement


### PR DESCRIPTION
With this correction there will no more `mismatched input '{}' expecting {';', '{', 'returns'}` in case of empty block, e.g. 
`constructor() {}`