### PR TITLE
Allow 'global' variable name

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -423,7 +423,7 @@ numberLiteral
 // some keywords need to be added here to avoid ambiguities
 // for example, "revert" is a keyword but it can also be a function name
 identifier
-  : ('from' | 'calldata' | 'receive' | 'callback' | 'revert' | 'error' | 'address' | ConstructorKeyword | PayableKeyword | LeaveKeyword | Identifier) ;
+  : ('from' | 'calldata' | 'receive' | 'callback' | 'revert' | 'error' | 'address' | GlobalKeyword | ConstructorKeyword | PayableKeyword | LeaveKeyword | Identifier) ;
 
 BooleanLiteral
   : 'true' | 'false' ;

--- a/test.sol
+++ b/test.sol
@@ -1048,6 +1048,13 @@ contract Foo {
   }
 }
 
+
+contract GlobalVarName {
+    function test() pure {
+        uint256 global = 1;
+    }
+}
+
 // solc 0.8.18, named parameters in mapping types
 contract NamedMappingParams {
   mapping (address => bool) m1;


### PR DESCRIPTION
Allows `global` to be a variable name while parsing without breaking linting