### PR TITLE
Feat: Upgrade to Antlr 4.8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,38 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+echo "$JAVA_HOME" 
+
 
 ANTLR_JAR="antlr4.jar"
+ANTLR_JAR_URI="https://www.antlr.org/download/antlr-4.8-complete.jar"
+
 
 GRAMMAR="Solidity"
 START_RULE="sourceUnit"
 TEST_FILE="test.sol"
 ERROR_PATTERN="mismatched|extraneous"
 
-if [ ! -e "$ANTLR_JAR" ]; then
-  curl https://www.antlr.org/download/antlr-4.7.2-complete.jar -o "$ANTLR_JAR"
-fi
+function download_antlr4
+{
+  if [[ ! -e "$ANTLR_JAR" ]]
+  then
+    curl -sL "${ANTLR_JAR_URI}" -o "${ANTLR_JAR}" 
+  fi
+}
+
+echo "Downloading Antlr 4.8..."
+
+download_antlr4
 
 mkdir -p target/
 
+echo "Creating parser"
+(
 java -jar $ANTLR_JAR $GRAMMAR.g4 -o src/
+sleep 1
 javac -classpath $ANTLR_JAR src/*.java -d target/
+)
 
-
+echo "Artifacts Generated"
+exit 0


### PR DESCRIPTION
The `ethereum/solidity` repo is using Antlr4.8. 

I think there should be at least cross testing to see if the output is materially different, less grammar differences from the separate definitions. 

Alternatively, it may be worth considering bundling a separate build output using their grammar and referring to that as the "Strict" parser for consumers to consider relative to their use case.

>**Note**    
> The test script must be updated -- I wanted to first open the PR and see your thoughts before going further.   


Cheers