### PR TITLE
Cleanup

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -501,8 +501,7 @@ stringLiteral
   : StringLiteralFragment+ ;
 
 StringLiteralFragment
-  : 'unicode'? '"' DoubleQuotedStringCharacter* '"'
-  | 'unicode'? '\'' SingleQuotedStringCharacter* '\'' ;
+  : 'unicode'? ( '"' DoubleQuotedStringCharacter* '"' | '\'' SingleQuotedStringCharacter* '\'' ) ;
 
 fragment
 DoubleQuotedStringCharacter

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -267,19 +267,27 @@ elementaryTypeName
   : 'address' | 'bool' | 'string' | 'var' | Int | Uint | 'byte' | Byte | Fixed | Ufixed ;
 
 Int
-  : 'int' | 'int8' | 'int16' | 'int24' | 'int32' | 'int40' | 'int48' | 'int56' | 'int64' | 'int72' | 'int80' | 'int88' | 'int96' | 'int104' | 'int112' | 'int120' | 'int128' | 'int136' | 'int144' | 'int152' | 'int160' | 'int168' | 'int176' | 'int184' | 'int192' | 'int200' | 'int208' | 'int216' | 'int224' | 'int232' | 'int240' | 'int248' | 'int256' ;
+  : 'int' (NumberOfBits)? ;
 
 Uint
-  : 'uint' | 'uint8' | 'uint16' | 'uint24' | 'uint32' | 'uint40' | 'uint48' | 'uint56' | 'uint64' | 'uint72' | 'uint80' | 'uint88' | 'uint96' | 'uint104' | 'uint112' | 'uint120' | 'uint128' | 'uint136' | 'uint144' | 'uint152' | 'uint160' | 'uint168' | 'uint176' | 'uint184' | 'uint192' | 'uint200' | 'uint208' | 'uint216' | 'uint224' | 'uint232' | 'uint240' | 'uint248' | 'uint256' ;
+  : 'uint' (NumberOfBits)? ;
 
 Byte
-  : 'bytes' | 'bytes1' | 'bytes2' | 'bytes3' | 'bytes4' | 'bytes5' | 'bytes6' | 'bytes7' | 'bytes8' | 'bytes9' | 'bytes10' | 'bytes11' | 'bytes12' | 'bytes13' | 'bytes14' | 'bytes15' | 'bytes16' | 'bytes17' | 'bytes18' | 'bytes19' | 'bytes20' | 'bytes21' | 'bytes22' | 'bytes23' | 'bytes24' | 'bytes25' | 'bytes26' | 'bytes27' | 'bytes28' | 'bytes29' | 'bytes30' | 'bytes31' | 'bytes32' ;
+  : 'bytes' (NumberOfBytes)?;
 
 Fixed
-  : 'fixed' | ( 'fixed' [0-9]+ 'x' [0-9]+ ) ;
+  : 'fixed' ( NumberOfBits 'x' [0-9]+ )? ;
 
 Ufixed
-  : 'ufixed' | ( 'ufixed' [0-9]+ 'x' [0-9]+ ) ;
+  : 'ufixed' ( NumberOfBits 'x' [0-9]+ )? ;
+
+fragment
+NumberOfBits
+  : '8' | '16' | '24' | '32' | '40' | '48' | '56' | '64' | '72' | '80' | '88' | '96' | '104' | '112' | '120' | '128' | '136' | '144' | '152' | '160' | '168' | '176' | '184' | '192' | '200' | '208' | '216' | '224' | '232' | '240' | '248' | '256' ;
+
+fragment
+NumberOfBytes
+  : [1-9] | [12] [0-9] | '3' [0-2] ;
 
 expression
   : expression ('++' | '--')

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -459,31 +459,8 @@ hexLiteral : HexLiteralFragment+ ;
 HexLiteralFragment : 'hex' ('"' HexDigits? '"' | '\'' HexDigits? '\'') ;
 
 fragment
-HexPair
-  : HexCharacter HexCharacter ;
-
-fragment
 HexCharacter
   : [0-9A-Fa-f] ;
-
-ReservedKeyword
-  : 'abstract'
-  | 'after'
-  | 'case'
-  | 'catch'
-  | 'default'
-  | 'final'
-  | 'in'
-  | 'inline'
-  | 'let'
-  | 'match'
-  | 'null'
-  | 'of'
-  | 'relocatable'
-  | 'static'
-  | 'switch'
-  | 'try'
-  | 'typeof' ;
 
 AnonymousKeyword : 'anonymous' ;
 BreakKeyword : 'break' ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -462,6 +462,25 @@ fragment
 HexCharacter
   : [0-9A-Fa-f] ;
 
+ReservedKeyword
+  : 'abstract'
+  | 'after'
+  | 'case'
+  | 'catch'
+  | 'default'
+  | 'final'
+  | 'in'
+  | 'inline'
+  | 'let'
+  | 'match'
+  | 'null'
+  | 'of'
+  | 'relocatable'
+  | 'static'
+  | 'switch'
+  | 'try'
+  | 'typeof' ;
+
 AnonymousKeyword : 'anonymous' ;
 BreakKeyword : 'break' ;
 ConstantKeyword : 'constant' ;


### PR DESCRIPTION
adding the number of bits and bytes of the variable types as a fragment to avoid repetition creating smaller and reused rules.

removing unused rules

So far all tests pass in this repo, in `solidity-parser/parser` and in `prettier-plugin-solidity` with these changes and the built file is smaller thanks to this.