### PR TITLE
Fix `ElementaryTypeName` state mutability parsing

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -151,12 +151,12 @@ variableDeclaration
   : typeName storageLocation? identifier ;
 
 typeName
-  : elementaryTypeName
+  : elementaryTypeName stateMutability?
   | userDefinedTypeName
   | mapping
   | typeName '[' expression? ']'
   | functionTypeName
-  | 'address' 'payable' ;
+  | 'address';
 
 userDefinedTypeName
   : identifier ( '.' identifier )* ;

--- a/test.sol
+++ b/test.sol
@@ -1071,3 +1071,5 @@ contract NamedMappingParams {
 // solc 0.8.19, user defined operators
 using { add as + } for Fixed18 global;
 using { add as +, sub as - } for Fixed18 global;
+
+function test() public returns(address payable) {}


### PR DESCRIPTION
Example:

```solidity
function test() public returns(address payable) {}
```

Now:
- `address` - type 🟢
- `payable` - identifier 🔴
- `None` - state mutability 🔴

Need:
- `address` - type 🟢
- `payable` - state mutability 🟢
- `None` - identifier 🟢