### PR TITLE
Add missing reserved keywords

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -464,22 +464,34 @@ HexCharacter
   : [0-9A-Fa-f] ;
 
 ReservedKeyword
-  : 'abstract'
-  | 'after'
+  : 'after'
+  | 'alias'
+  | 'apply'
+  | 'auto'
   | 'case'
-  | 'catch'
+  | 'copyof'
   | 'default'
+  | 'define'
   | 'final'
+  | 'implements'
   | 'in'
   | 'inline'
   | 'let'
+  | 'macro'
   | 'match'
+  | 'mutable'
   | 'null'
   | 'of'
+  | 'partial'
+  | 'promise'
+  | 'reference'
   | 'relocatable'
+  | 'sealed'
+  | 'sizeof'
   | 'static'
+  | 'supports'
   | 'switch'
-  | 'try'
+  | 'typedef'
   | 'typeof' ;
 
 AnonymousKeyword : 'anonymous' ;


### PR DESCRIPTION
Updated the list of reserved Solidity keywords as specified in the [documentation](https://docs.soliditylang.org/en/v0.8.26/units-and-global-variables.html#reserved-keywords). Also removed `abstract`, `try`, and `catch` reserved keywords as they are matched before `ReservedKeyword` statement.